### PR TITLE
APQ Queries should be validated before storing.

### DIFF
--- a/graphql_apq.services.yml
+++ b/graphql_apq.services.yml
@@ -10,4 +10,13 @@ services:
     class: Drupal\graphql_apq\GraphQL\QueryProvider\APQQueryMapQueryProvider
     arguments: ['@entity_type.manager']
     tags:
-        - { name: graphql_query_provider, priority: 10 }
+      - { name: graphql_query_provider, priority: 10 }
+
+  # Schema and processor factory.
+  graphql_apq.query_processor:
+    class: Drupal\graphql_apq\GraphQL\Execution\APQQueryProcessor
+    arguments:
+      - '@cache_contexts_manager'
+      - '@plugin.manager.graphql.schema'
+      - '@cache.graphql.results'
+      - '@request_stack'

--- a/src/Controller/APQRequestController.php
+++ b/src/Controller/APQRequestController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\graphql_apq\Controller;
+
+use Drupal\graphql\Controller\RequestController;
+use Drupal\graphql_apq\GraphQL\Execution\APQQueryProcessor;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Handles APQ GraphQL requests.
+ */
+class APQRequestController extends RequestController {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('graphql_apq.query_processor'),
+      $container->getParameter('graphql.config')
+    );
+  }
+
+  /**
+   * @inheritDoc
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager service.
+   */
+  public function __construct(APQQueryProcessor $processor, array $parameters) {
+    parent::__construct($processor, $parameters);
+  }
+
+}

--- a/src/GraphQL/Execution/APQQueryProcessor.php
+++ b/src/GraphQL/Execution/APQQueryProcessor.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Drupal\graphql_apq\GraphQL\Execution;
+
+use Drupal\graphql\GraphQL\Execution\QueryProcessor;
+use GraphQL\Language\AST\DocumentNode;
+use GraphQL\Language\Parser;
+use GraphQL\Server\OperationParams;
+use GraphQL\Server\ServerConfig;
+
+class APQQueryProcessor extends QueryProcessor {
+
+  /**
+   * @inheritDoc
+   */
+  public function processQuery($schema, $params) {
+    // Load the plugin from the schema manager.
+    $plugin = $this->pluginManager->createInstance($schema);
+    $config = $plugin->getServer();
+
+    $this->storeAPQQuery($config, $params);
+
+    if (is_array($params)) {
+      return $this->executeBatch($config, $params);
+    }
+
+    return $this->executeSingle($config, $params);
+  }
+
+  /**
+   * Store APQ Query.
+   *
+   * @param \GraphQL\Server\ServerConfig $config
+   * @param \GraphQL\Server\OperationParams $params
+   *
+   * @throws \GraphQL\Error\SyntaxError
+   * @throws \GraphQL\Server\RequestError
+   */
+  private function storeAPQQuery(ServerConfig $config, OperationParams $params) {
+    // Request without query.
+    if (empty($params->getOriginalInput('query'))) {
+      return;
+    }
+
+    // Query is invalid.
+    if (!$this->validateAPQQuery($config, $params)) {
+      return;
+    }
+
+    $persistedQuery = $this->persistedQuery($params);
+    $storage = \Drupal::entityTypeManager()->getStorage('apq_query_map');
+
+    // Query is already stored.
+    if (
+      !empty(
+        $storage->loadByProperties([
+          'version' => $persistedQuery['version'],
+          'hash' => $persistedQuery['sha256Hash'],
+        ])
+      )
+    ) {
+      return;
+    }
+
+    // We can now store valid query.
+    $apq = $storage->create([
+      'version' => $persistedQuery['version'],
+      'query' => $params->getOriginalInput('query'),
+      'hash' => $persistedQuery['sha256Hash'],
+    ]);
+    $apq->save();
+  }
+
+  /**
+   * Check if is APQ Query valid.
+   *
+   * @param \GraphQL\Server\ServerConfig $config
+   * @param \GraphQL\Server\OperationParams $params
+   *
+   * @return bool
+   * @throws \GraphQL\Error\SyntaxError
+   * @throws \GraphQL\Server\RequestError
+   */
+  private function validateAPQQuery(ServerConfig $config, OperationParams $params): bool {
+    $document = $this->getDocumentFromQuery($config, $params);
+    return $this->operationParamsValid($params) && $this->operationValid($config, $params, $document);
+  }
+
+  /**
+   * Check if operation params are valid.
+   *
+   * @param \GraphQL\Server\OperationParams $params
+   *
+   * @return bool
+   */
+  private function operationParamsValid(OperationParams $params) {
+    return count($this->validateOperationParams($params)) === 0;
+  }
+
+  /**
+   * Check if operation is valid.
+   *
+   * @param \GraphQL\Server\ServerConfig $config
+   * @param \GraphQL\Server\OperationParams $params
+   * @param \GraphQL\Language\AST\DocumentNode $document
+   *
+   * @return bool
+   * @throws \Exception
+   */
+  private function operationValid(ServerConfig $config, OperationParams $params, DocumentNode $document) {
+    return count($this->validateOperation($config, $params, $document)) === 0;
+  }
+
+  /**
+   * Get DocumentNode from query.
+   *
+   * @param \GraphQL\Server\ServerConfig $config
+   * @param \GraphQL\Server\OperationParams $params
+   *
+   * @return \GraphQL\Language\AST\DocumentNode
+   * @throws \GraphQL\Error\SyntaxError
+   * @throws \GraphQL\Server\RequestError
+   */
+  private function getDocumentFromQuery(ServerConfig $config, OperationParams $params): DocumentNode {
+    $document = $params->queryId ? $this->loadPersistedQuery($config, $params) : $params->query;
+    if (!$document instanceof DocumentNode) {
+      $document = Parser::parse($document);
+    }
+    return $document;
+  }
+
+  /**
+   * Return persisted query extension or false.
+   *
+   * @param \GraphQL\Server\OperationParams $params
+   *
+   * @return bool | array
+   */
+  private function persistedQuery(OperationParams $params) {
+    $extensions = $params->getOriginalInput('extensions');
+    return empty($extensions['persistedQuery']) ? false : $extensions['persistedQuery'];
+  }
+
+}

--- a/src/GraphQL/QueryProvider/APQQueryMapQueryProvider.php
+++ b/src/GraphQL/QueryProvider/APQQueryMapQueryProvider.php
@@ -3,9 +3,9 @@
 namespace Drupal\graphql_apq\GraphQL\QueryProvider;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\graphql\GraphQL\QueryProvider\QueryProviderInterface;
 use GraphQL\Server\OperationParams;
 use GraphQL\Server\RequestError;
-use Drupal\graphql\GraphQL\QueryProvider\QueryProviderInterface;
 
 class APQQueryMapQueryProvider implements QueryProviderInterface {
 
@@ -30,58 +30,40 @@ class APQQueryMapQueryProvider implements QueryProviderInterface {
    * {@inheritdoc}
    */
   public function getQuery($id, OperationParams $operation) {
-    $extensions = $operation->getOriginalInput('extensions');
-
     // Early skip if no persistedQuery protocol implemented in operation.
-    if (empty($extensions['persistedQuery'])) {
+    $persistedQuery = $this->persistedQuery($operation);
+    if (!$persistedQuery) {
       return NULL;
-    }
-
-    list($version, $hash) = explode(':', $id);
-
-    // Check that the hash is properly formatted.
-    if (empty($version) || empty($hash)) {
-      return NULL;
-    }
-
-    $storage = $this->entityTypeManager->getStorage('apq_query_map');
-
-    $apqs = $storage->loadByProperties([
-      'version' => $version,
-      'hash' => $hash,
-    ]);
-
-    $apq = empty($apqs) ? NULL : reset($apqs);
-    
-    // Let default handler work in case query is already cached.
-    if (!empty($operation->originalQuery) && !empty($apq)) {
-      return $operation->originalQuery;
     }
 
     // Retrieve query in case we have it cached.
-    if (empty($operation->originalQuery) && !empty($apq)) {
+    $storage = $this->entityTypeManager->getStorage('apq_query_map');
+    $apqs = $storage->loadByProperties([
+      'version' => $persistedQuery['version'],
+      'hash' => $persistedQuery['sha256Hash'],
+    ]);
+    $apq = empty($apqs) ? NULL : reset($apqs);
+    if (!empty($apq)) {
       return $apq->getQuery();
     }
 
-    // Add the query to the cache in case we don't have it yet.
-    if (!empty($operation->originalQuery) && empty($apq)) {
-      $apq = $storage->create([
-        'version' => $version,
-        'query' => $operation->originalQuery,
-        'hash' => $hash,
-      ]);
-
-      $apq->save();
-
-      return $operation->originalQuery;
+    // Send original query if is present.
+    $originalQuery = $operation->getOriginalInput('query');
+    if (empty($apq) && !empty($originalQuery)) {
+      return $originalQuery;
     }
 
-    // In case no query is set after all tries,
-    // respond with PersistedQueryNotFound to allow fulfilling.
+    // In case no query is cached, respond with PersistedQueryNotFound to
+    // allow fulfilling.
     if (empty($operation->originalQuery)) {
       throw new RequestError('PersistedQueryNotFound');
     }
 
     return NULL;
+  }
+
+  private function persistedQuery(OperationParams $operation) {
+    $extensions = $operation->getOriginalInput('extensions');
+    return empty($extensions['persistedQuery']) ? false : $extensions['persistedQuery'];
   }
 }


### PR DESCRIPTION
GraphQL queries stored in apq_query_map table even if query is invalid (for example query has field which is not exist on GraphQL scheme). This PR introduce query validation before store.