### PR TITLE
Make D9 compatible

### DIFF
--- a/graphql_apq.info.yml
+++ b/graphql_apq.info.yml
@@ -1,7 +1,7 @@
 name: 'Graphql APQ'
 type: module
 description: 'Automatic persisted queries for GraphQL.'
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: 'GraphQL'
 dependencies:
   - graphql

--- a/src/Routing/APQRouteEnhancer.php
+++ b/src/Routing/APQRouteEnhancer.php
@@ -3,6 +3,7 @@
 namespace Drupal\graphql_apq\Routing;
 
 use Drupal\graphql\Routing\QueryRouteEnhancer;
+use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 class APQRouteEnhancer extends QueryRouteEnhancer {
@@ -11,6 +12,11 @@ class APQRouteEnhancer extends QueryRouteEnhancer {
    * {@inheritdoc}
    */
   public function enhance(array $defaults, Request $request) {
+    $route = $defaults[RouteObjectInterface::ROUTE_OBJECT];
+    if (!$route->hasDefault('_graphql')) {
+      return $defaults;
+    }
+
     if ($persistedQuery = $this->persistedQuery($defaults)) {
       $defaults['_controller'] = "\Drupal\graphql_apq\Controller\APQRequestController::handleRequest";
       if (empty($defaults['operations']->queryId)) {


### PR DESCRIPTION
The RouteEnhancerInterface changes in Drupal 9, so the applies method in the main GraphQL method can no longer be relied upon to check the route.